### PR TITLE
Fix drum init and adjust pedal class

### DIFF
--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -234,6 +234,8 @@ class DrumGenerator(BasePartGenerator):
             main_cfg=main_cfg,
             groove_profile=groove_profile,
         )
+        # Guarantee main_cfg attribute for compatibility
+        self.main_cfg = main_cfg or {}
         # もし、この後に独自の初期化処理があれば、ここに残してください。
         # 例：
         # if self.part_name == "bass":
@@ -378,6 +380,9 @@ class DrumGenerator(BasePartGenerator):
         # drum_patterns.yml をロード
         with open("data/drum_patterns.yml", encoding="utf-8") as f:
             drum_patterns = yaml.safe_load(f)
+
+        # Ensure essential drum patterns exist
+        self._add_internal_default_patterns()
 
     def _choose_pattern_key(self, emotion: str | None, intensity: str | None) -> str:
         emo = (emotion or "default").lower()
@@ -1019,13 +1024,6 @@ class DrumGenerator(BasePartGenerator):
         }
         return self._render_part(dummy_section)
 
-    def __init__(self, *args, **kwargs):
-        """全てのジェネレーターで統一された初期化メソッド"""
-        super().__init__(*args, **kwargs)
-        self.rng = random.Random()
-        if self.main_cfg.get("rng_seed") is not None:
-            self.rng.seed(self.main_cfg["rng_seed"])
-        self._add_internal_default_patterns()
 
     def _add_internal_default_patterns(self):
         """ライブラリに必須パターンがなければ、最低限のフォールバックを追加"""

--- a/generator/piano_generator.py
+++ b/generator/piano_generator.py
@@ -18,7 +18,6 @@ from music21 import (
     interval,
     volume as m21volume,
     pitch,
-    pedal,  # 🟨ここを修正🟨: pedal をインポート
 )
 
 from .base_part_generator import BasePartGenerator
@@ -260,7 +259,7 @@ class PianoGenerator(BasePartGenerator):
             return
         t = 0.0
         while t < end_offset:
-            ped = pedal.Pedal()
+            ped = expressions.PedalMark()
             part.insert(t, ped)
             t += sustain_beats
 


### PR DESCRIPTION
## Summary
- ensure `DrumGenerator` always has a `main_cfg` field and set up default patterns during init
- use `expressions.PedalMark` instead of deprecated `pedal` import in `PianoGenerator`

## Testing
- `python3 -m py_compile generator/drum_generator.py generator/piano_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6844f6bedce8832880c71f73ee5c5318