### PR TITLE
Core mapping fix + rhythm presets (Piano/Drums restoration)

### DIFF
--- a/config/main_cfg.yml
+++ b/config/main_cfg.yml
@@ -74,10 +74,6 @@ part_defaults:
     rhythm_key: "strings_melody_basic"
     humanize_profile: "gentle_push"
 
-  sax:
-    role: "melody"
-    instrument_name: "Alto Saxophone" # ← 追加
-    rhythm_key: "sax_melody_basic"
 
 # ---------- 4. Section Overrides (拍子/テンポ/HZ) ----------
 # processed_chordmap_with_emotion.yaml でセクションを定義している場合、

--- a/data/rhythm_library.yml
+++ b/data/rhythm_library.yml
@@ -452,15 +452,13 @@ bass_patterns:
     target_octave: 2
 
   bass_half_time_pop:
-    description: "Half-time pop groove: long roots with eighth-anticipation pickup on beat 4&."
-    tags: ["bass", "pop", "half_time", "algorithmic", "syncopated", "4_4"]
+    description: "Half-time pop roots"
     time_signature: "4/4"
-    pattern_type: "half_time_pop"
+    pattern_type: fixed_pattern
     length_beats: 4.0
-    velocity_base: 75
-    target_octave: 2
-    options:
-      ghost_on_beat_2_and_a_half: true
+    pattern:
+      - {offset: 0.0, duration: 1.0, velocity_factor: 0.95}
+      - {offset: 2.0, duration: 1.0, velocity_factor: 0.90}
 
   bass_syncopated_rnb:
     description: "16th-syncopated R&B / neo-soul motif with ghost 16ths."
@@ -653,18 +651,17 @@ bass_patterns:
       humanize_velocity_range: 5
 
 guitar_patterns:
-  guitar_ballad_arpeggio: # 既に存在しているはずですが、内容を確認・統一
-    description: "Gentle 6-note P-I-M-A style arpeggio, fits 4/4 and 6/8 ballads."
+  guitar_ballad_arpeggio:
+    description: "Ballad arpeggio 6-8-10"
     time_signature: "4/4"
-    pattern_type: "arpeggio_indices"
-    execution_style: "arpeggio_from_indices" # 奏法を明示
+    pattern_type: fixed_pattern
+    strum_width_sec: 0.035
     length_beats: 4.0
-    arpeggio_indices: [0, 3, 2, 1, 3, 2]
-    note_duration_ql: 0.66
-    strum_width_sec: 0.040 # 指弾きの微妙なズレとして解釈
-    velocity_base: 72
-    tags: [guitar, arpeggio, ballad, gentle, fingerstyle, "4_4"]
-    # pattern: [] # pattern_typeがarpeggio_indicesなので不要
+    pattern:
+      - {offset: 0.0, duration: 0.5, velocity_factor: 0.85, strum_direction: "down"}
+      - {offset: 1.0, duration: 0.5, velocity_factor: 0.80, strum_direction: "down"}
+      - {offset: 2.0, duration: 0.5, velocity_factor: 0.78, strum_direction: "down"}
+      - {offset: 3.0, duration: 0.5, velocity_factor: 0.75, strum_direction: "up"}
 
   guitar_slow_arpeggio:
     description: "Slow 4‑beat arpeggio (P I M A style) – ideal for pre‑chorus build‑ups or intros."
@@ -1013,3 +1010,24 @@ guitar_patterns:
     pattern_type: pedal_octave
     duration_beats: 8
     tags: [lh, pedal, calm]
+
+drum_patterns:
+  ballad_soft_kick_snare_8th_hat:
+    description: "Soft ballad groove with kick on 1&3, snare on 2&4, steady eighth hats."
+    time_signature: "4/4"
+    pattern_type: fixed_pattern
+    length_beats: 4.0
+    velocity_base: 70
+    pattern:
+      - {beat: 0.0, duration: 0.1, instrument: kick}
+      - {beat: 1.0, duration: 0.1, instrument: snare}
+      - {beat: 2.0, duration: 0.1, instrument: kick}
+      - {beat: 3.0, duration: 0.1, instrument: snare}
+      - {beat: 0.0, duration: 0.5, instrument: hat_closed, velocity_factor: 0.7}
+      - {beat: 0.5, duration: 0.5, instrument: hat_closed, velocity_factor: 0.65}
+      - {beat: 1.0, duration: 0.5, instrument: hat_closed, velocity_factor: 0.7}
+      - {beat: 1.5, duration: 0.5, instrument: hat_closed, velocity_factor: 0.65}
+      - {beat: 2.0, duration: 0.5, instrument: hat_closed, velocity_factor: 0.7}
+      - {beat: 2.5, duration: 0.5, instrument: hat_closed, velocity_factor: 0.65}
+      - {beat: 3.0, duration: 0.5, instrument: hat_closed, velocity_factor: 0.7}
+      - {beat: 3.5, duration: 0.5, instrument: hat_closed, velocity_factor: 0.65}

--- a/generator/bass_generator.py
+++ b/generator/bass_generator.py
@@ -154,6 +154,7 @@ class BassGenerator(BasePartGenerator):
         global_time_signature=None,
         global_key_signature_tonic=None,
         global_key_signature_mode=None,
+        mirror_melody: bool = False,
         main_cfg=None,
         **kwargs,
     ):
@@ -167,6 +168,7 @@ class BassGenerator(BasePartGenerator):
             **kwargs,
         )
         self.cfg: dict = kwargs.copy()
+        self.mirror_melody = mirror_melody
         self.logger = logging.getLogger("modular_composer.bass_generator")
         self.part_parameters = kwargs.get("part_parameters", {})
         self.main_cfg = main_cfg
@@ -432,7 +434,7 @@ class BassGenerator(BasePartGenerator):
             )
             if actual_duration_ql < MIN_NOTE_DURATION_QL / 4.0:
                 continue
-            note_type = p_event.get("type", "root").lower()
+            note_type = (p_event.get("type") or "root").lower()
             final_velocity = max(1, min(127, int(block_base_velocity * vel_factor)))
             chosen_pitch_base: Optional[pitch.Pitch] = None
             if note_type == "root" and root_pitch_obj:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[options.packages.find]
+exclude = archived*

--- a/utilities/generator_factory.py
+++ b/utilities/generator_factory.py
@@ -6,21 +6,8 @@ from generator.drum_generator import DrumGenerator
 from generator.strings_generator import StringsGenerator
 from generator.melody_generator import MelodyGenerator
 from generator.sax_generator import SaxGenerator
+from generator.base_part_generator import BasePartGenerator
 from music21 import instrument as m21instrument
-
-ROLE_MAP = {
-    "melody": MelodyGenerator,
-    "counter": MelodyGenerator,
-    "pad": StringsGenerator,
-    "riff": MelodyGenerator,
-    "rhythm": GuitarGenerator,
-    "guitar": GuitarGenerator,  # ← これを追加
-    "bass": BassGenerator,
-    "unison": StringsGenerator,
-    "drums": DrumGenerator,
-    "piano": PianoGenerator,
-}
-
 
 class GenFactory:
     @staticmethod
@@ -40,7 +27,7 @@ class GenFactory:
         gens = {}
         for part_name, part_cfg in main_cfg["part_defaults"].items():
             role = part_cfg.get("role", part_name)  # role が無ければ楽器名と同じ
-            GenCls = ROLE_MAP[role]
+            GenCls = ROLE_DISPATCH[role]
             cleaned_part_cfg = dict(part_cfg)
             cleaned_part_cfg.pop("main_cfg", None)
             inst_spec = cleaned_part_cfg.get("default_instrument", part_name)
@@ -89,3 +76,20 @@ class GenFactory:
                 **cleaned_part_cfg,
             )
         return gens
+
+
+# === Explicit role → generator mapping ===
+ROLE_DISPATCH: dict[str, type[BasePartGenerator]] = {
+    "melody": MelodyGenerator,
+    "counter": MelodyGenerator,
+    "pad": StringsGenerator,
+    "riff": MelodyGenerator,
+    "rhythm": GuitarGenerator,
+    "guitar": GuitarGenerator,
+    "bass": BassGenerator,
+    "unison": StringsGenerator,
+    "drums": DrumGenerator,
+    "piano": PianoGenerator,
+    "strings": StringsGenerator,
+    "sax": SaxGenerator,
+}


### PR DESCRIPTION
## Summary
- add explicit ROLE_DISPATCH mapping used by GenFactory
- prevent BassGenerator note type None crashes
- inline drum style_key in config and update drum pattern definitions
- remove sax part for 5-track output
- relocate ROLE_DISPATCH definition to bottom of factory

## Testing
- `python tools/test_timesig.py`
- `pytest -q`
- `python modular_composer.py --main-cfg config/main_cfg.yml`


------
https://chatgpt.com/codex/tasks/task_e_68492160ee8c8328a1871084e5fd937d