### PR TITLE
Exclude archived JP package

### DIFF
--- a/"b/\343\202\242\343\203\274\343\202\253\343\202\244\343\203\226/__init__.py"
+++ b/"b/\343\202\242\343\203\274\343\202\253\343\202\244\343\203\226/__init__.py"
@@ -1,0 +1,1 @@
+raise ImportError("The 'アーカイブ' package is archived and should not be imported")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [options.packages.find]
-exclude = archived*
+exclude = archived*, アーカイブ*


### PR DESCRIPTION
## Summary
- prevent accidental packaging of the Japanese archive directory
- guard imports from the archive directory

## Testing
- `python tools/test_timesig.py`
- `pytest -q`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68497570e38083288b497d50e74449e7