### PR TITLE
Add CLI overrides for chordmap and rhythm

### DIFF
--- a/config/main_cfg.yml
+++ b/config/main_cfg.yml
@@ -25,8 +25,8 @@ global_settings:
 
 # ------------------- 2. Paths -----------------------
 paths:
-  chordmap_path: "../data/processed_chordmap_with_emotion.yaml"
-  rhythm_library_path: "../data/rhythm_library.yml"
+  chordmap: "../data/processed_chordmap_with_emotion.yaml"
+  rhythm_library: "../data/rhythm_library.yml"
   arrangement_overrides_path: "../data/arrangement_overrides.json"
   vocal_heatmap_path: "../data/heatmap.json"
   vocal_note_data_path: "../data/vocal_note_data_ore.json"

--- a/utilities/config_loader.py
+++ b/utilities/config_loader.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("otokotoba.config_loader")
 # -- デフォルト必須キー一覧（存在しない場合は補完 or エラー） --
 REQUIRED_TOP_LEVEL = {"global_settings", "paths", "part_defaults"}
 REQUIRED_GLOBAL_SETTINGS = {"time_signature", "tempo_bpm", "key_tonic", "key_mode"}
-REQUIRED_PATHS = {"chordmap_path", "rhythm_library_path", "output_dir"}
+REQUIRED_PATHS = {"chordmap", "rhythm_library", "output_dir"}
 
 
 # --- 許容される役割リスト（ドキュメント・自動補完・静的チェック用） ---


### PR DESCRIPTION
## Summary
- add `--chordmap` and `--rhythm` args in `modular_composer.py`
- merge CLI overrides into `main_cfg["paths"]` and log paths
- rename path keys in config and loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849742c62d483289a86fe58ee7fc14c