### PR TITLE
Add project setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Composer Project
+
+This repository combines Japanese poetry readings with emotional original music. The goal is to divide stories or poems into chapters and automatically generate and integrate chord progressions, melodies, arrangements, and human-like expression for each section.
+
+## Setup
+
+1. Create and activate a Python virtual environment:
+   ```bash
+   python3 -m venv .venv && source .venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt pyyaml
+   ```
+3. Run the test script and the full test suite:
+   ```bash
+   python tools/test_timesig.py
+   pytest -q
+   ```
+
+These steps will ensure the environment is configured to run the project tools and tests.


### PR DESCRIPTION
## Summary
- add a README with a brief project description
- document commands for setting up the virtual environment, installing dependencies, running a sample script, and running tests

## Testing
- `python tools/test_timesig.py`
- `pytest -q` *(fails: fixture 'ts_str' not found)*

------
https://chatgpt.com/codex/tasks/task_e_684995518204832887e33f973a7b14fc