### PR TITLE
Update bass defaults

### DIFF
--- a/config/main_cfg.yml
+++ b/config/main_cfg.yml
@@ -56,6 +56,7 @@ part_defaults:
   bass:
     rhythm_key: "bass_pump_8th_octaves"
     velocity: 80
+    mirror_melody: false
     weak_beat_style: "none"
     humanize_profile: ""
     dynamics_profile: ""


### PR DESCRIPTION
## Summary
- disable bass mirror melody setting in the main config

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68499541ede08328861d329568332941