### PR TITLE
Add mirror_melody option for BassGenerator

### DIFF
--- a/generator/bass_generator.py
+++ b/generator/bass_generator.py
@@ -155,6 +155,7 @@ class BassGenerator(BasePartGenerator):
         global_key_signature_tonic=None,
         global_key_signature_mode=None,
         main_cfg=None,
+        mirror_melody: bool = False,
         **kwargs,
     ):
         super().__init__(
@@ -170,6 +171,7 @@ class BassGenerator(BasePartGenerator):
         self.logger = logging.getLogger("modular_composer.bass_generator")
         self.part_parameters = kwargs.get("part_parameters", {})
         self.main_cfg = main_cfg
+        self.mirror_melody = mirror_melody
         # ここで global_ts_str をセット
         self.global_ts_str = global_time_signature
         self.global_time_signature_obj = get_time_signature_object(self.global_ts_str)


### PR DESCRIPTION
## Summary
- allow BassGenerator to accept a `mirror_melody` flag
- store the flag on the instance

## Testing
- `pytest -q` *(fails: FileNotFoundError in test_timesig)*

------
https://chatgpt.com/codex/tasks/task_e_6849953b8b488328b4da30199a926762