### PR TITLE
Fix duplicate import in guitar generator

### DIFF
--- a/generator/guitar_generator.py
+++ b/generator/guitar_generator.py
@@ -9,7 +9,6 @@ import music21.harmony as harmony
 import music21.pitch as pitch
 import music21.meter as meter
 import music21.duration as music21_duration
-import music21.instrument as m21instrument
 import music21.interval as interval
 import music21.tempo as tempo
 import music21.chord as m21chord
@@ -17,7 +16,6 @@ import music21.articulations as articulations
 import music21.volume as m21volume
 from music21 import instrument as m21instrument
 
-# ...existing code...
 import random
 import logging
 import math


### PR DESCRIPTION
## Summary
- remove redundant `music21.instrument` import
- delete leftover placeholder comment
- `py_compile` the guitar generator to ensure syntax validity

## Testing
- `python -m py_compile generator/guitar_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68498d90b9e08328aa2adae00f677823