### PR TITLE
Remove unused mirror_melody option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Use `modular_composer.py` to generate MIDI after installing dependencies. Run th
 ```bash
 python3 modular_composer.py --main-cfg config/main_cfg.yml
 ```
+
+### Configuration Notes
+
+Instrument defaults are defined in `config/main_cfg.yml` under `part_defaults`.
+For bass parts the configurable options include `rhythm_key`, `velocity`, and
+`weak_beat_style`. The unused `mirror_melody` option has been removed.

--- a/generator/bass_generator.py
+++ b/generator/bass_generator.py
@@ -154,7 +154,6 @@ class BassGenerator(BasePartGenerator):
         global_time_signature=None,
         global_key_signature_tonic=None,
         global_key_signature_mode=None,
-        mirror_melody: bool = False,
         main_cfg=None,
         **kwargs,
     ):
@@ -168,7 +167,6 @@ class BassGenerator(BasePartGenerator):
             **kwargs,
         )
         self.cfg: dict = kwargs.copy()
-        self.mirror_melody = mirror_melody
         self.logger = logging.getLogger("modular_composer.bass_generator")
         self.part_parameters = kwargs.get("part_parameters", {})
         self.main_cfg = main_cfg


### PR DESCRIPTION
## Summary
- drop the `mirror_melody` parameter from `BassGenerator`
- mention configuration defaults in README

## Testing
- `pytest -q`
- `python tools/test_timesig.py`

------
https://chatgpt.com/codex/tasks/task_e_6849757779748328a9121791756bbec1