### PR TITLE
Implement music21-based onset heatmap

### DIFF
--- a/build_all_json.py
+++ b/build_all_json.py
@@ -3,47 +3,8 @@
 
 import sys
 import json
-from music21 import converter, note, chord, meter
-
-
-def build_heatmap(midi_path, resolution):
-    # （先ほどの onset_heatmap.py と同じ内容。略。）
-    score = converter.parse(midi_path)
-    ts = score.recurse().getElementsByClass(meter.TimeSignature)
-    if len(ts) == 0:
-        raise RuntimeError("拍子情報が見つかりませんでした。")
-    first_ts = ts[0]
-    beats_per_measure = first_ts.numerator
-    beat_unit = first_ts.denominator
-    quarter_per_measure = beats_per_measure * (4.0 / beat_unit)
-
-    onset_offsets = []
-    for el in score.recurse():
-        if isinstance(el, note.Note) or isinstance(el, chord.Chord):
-            onset_offsets.append(el.offset)
-    if len(onset_offsets) == 0:
-        raise RuntimeError("ノート（Note/Chord）のオンセットが見つかりませんでした。")
-
-    max_offset = max(onset_offsets)
-    total_measures = int(max_offset // quarter_per_measure) + 1
-    total_grids = total_measures * resolution
-    heatmap_counts = [0] * total_grids
-
-    for off in onset_offsets:
-        measure_index = int(off // quarter_per_measure)
-        offset_in_measure = off - (measure_index * quarter_per_measure)
-        subbeat_index = int((offset_in_measure / quarter_per_measure) * resolution)
-        if subbeat_index >= resolution:
-            subbeat_index = resolution - 1
-        grid_index = measure_index * resolution + subbeat_index
-        if 0 <= grid_index < total_grids:
-            heatmap_counts[grid_index] += 1
-
-    heatmap_list = []
-    for idx, cnt in enumerate(heatmap_counts):
-        heatmap_list.append({"grid_index": idx, "count": cnt})
-
-    return heatmap_list
+from music21 import converter, meter
+from utilities.onset_heatmap import build_heatmap
 
 
 def extract_tempo_map(midi_path):

--- a/utilities/onset_heatmap.py
+++ b/utilities/onset_heatmap.py
@@ -1,23 +1,84 @@
-from collections import Counter
-from typing import Dict, List
-import pretty_midi, json
+"""Utilities for creating onset heatmaps from MIDI files."""
 
-RESOLUTION = 16  # 16分=1グリッド
+from __future__ import annotations
 
+import json
+from typing import List
 
-def build_heatmap(midi_path: str, resolution: int = RESOLUTION) -> Dict[int, int]:
-    """MIDI からオンセット数ヒートマップ {grid_index:count}."""
-    pm = pretty_midi.PrettyMIDI(midi_path)
-    ticks_per_beat = pm.time_to_tick(1)  # 1 秒ではなく1拍分 tick
-    grid_ticks = ticks_per_beat / resolution
-    counter: Counter = Counter()
-    for inst in pm.instruments:
-        for n in inst.notes:
-            idx = int(n.start / pm.tick_to_time(grid_ticks))
-            counter[idx % resolution] += 1
-    return dict(counter)
+from music21 import converter, note, chord, meter
+
+RESOLUTION = 16  # number of grid bins per measure
 
 
-def save_heatmap_json(midi_path: str, out_json: str):
-    with open(out_json, "w") as f:
-        json.dump(build_heatmap(midi_path), f, indent=2)
+def build_heatmap(midi_path: str, resolution: int = RESOLUTION) -> List[int]:
+    """Parse a MIDI file and count note onsets per measure.
+
+    Parameters
+    ----------
+    midi_path:
+        Path to the MIDI file to analyse.
+    resolution:
+        Number of bins per measure. Default is ``RESOLUTION``.
+
+    Returns
+    -------
+    List[int]
+        Flattened list of onset counts. ``resolution`` elements are produced for
+        each measure in the MIDI file.
+    """
+    score = converter.parse(midi_path)
+
+    ts = score.recurse().getElementsByClass(meter.TimeSignature)
+    if len(ts) == 0:
+        raise RuntimeError("拍子情報が見つかりませんでした。")
+    first_ts = ts[0]
+    beats_per_measure = first_ts.numerator
+    beat_unit = first_ts.denominator
+    quarter_per_measure = beats_per_measure * (4.0 / beat_unit)
+
+    onset_offsets: List[float] = []
+    for el in score.recurse():
+        if isinstance(el, note.Note) or isinstance(el, chord.Chord):
+            onset_offsets.append(float(el.offset))
+
+    if len(onset_offsets) == 0:
+        raise RuntimeError("ノート（Note/Chord）のオンセットが見つかりませんでした。")
+
+    max_offset = max(onset_offsets)
+    total_measures = int(max_offset // quarter_per_measure) + 1
+    heatmap_counts = [0] * (total_measures * resolution)
+
+    for off in onset_offsets:
+        measure_index = int(off // quarter_per_measure)
+        offset_in_measure = off - (measure_index * quarter_per_measure)
+        subbeat_index = int((offset_in_measure / quarter_per_measure) * resolution)
+        if subbeat_index >= resolution:
+            subbeat_index = resolution - 1
+        grid_index = measure_index * resolution + subbeat_index
+        if 0 <= grid_index < len(heatmap_counts):
+            heatmap_counts[grid_index] += 1
+
+    return heatmap_counts
+
+
+def save_heatmap_json(midi_path: str, out_json: str, resolution: int = RESOLUTION) -> None:
+    """Save heatmap as a JSON file compatible with :func:`load_heatmap_data`."""
+    counts = build_heatmap(midi_path, resolution)
+    data = [{"grid_index": idx, "count": cnt} for idx, cnt in enumerate(counts)]
+    with open(out_json, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate onset heatmap JSON from a MIDI file")
+    parser.add_argument("midi_path", help="Input MIDI file")
+    parser.add_argument("resolution", type=int, nargs="?", default=RESOLUTION, help="Bins per measure")
+    parser.add_argument("output", nargs="?", default="heatmap.json", help="Output JSON path")
+    args = parser.parse_args()
+
+    try:
+        save_heatmap_json(args.midi_path, args.output, args.resolution)
+    except Exception as e:  # pragma: no cover - CLI feedback
+        parser.exit(1, f"Error: {e}\n")


### PR DESCRIPTION
## Summary
- implement a music21-based heatmap in `utilities/onset_heatmap.py`
- expose a CLI for generating heatmap JSON
- simplify `build_all_json.py` to rely on the new heatmap function

## Testing
- `python utilities/onset_heatmap.py data/vocal_ore.midi 16 test_heatmap.json && head -n 5 test_heatmap.json`
- `python -m compileall -q utilities/onset_heatmap.py build_all_json.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d13efdd883289a0dc44590ed03dc