### PR TITLE
Update onset heatmap config

### DIFF
--- a/config/main_cfg.yml
+++ b/config/main_cfg.yml
@@ -22,6 +22,9 @@ global_settings:
   # 外部プロファイル / マップ
   groove_profile_path: "data/groove_profile.json" # 微小タイミング揺らぎの統計
   tempo_map_path: "data/tempo_map.json" # rit. / accel. を含む細粒度 BPM 変化
+  onset_heatmap_json: "data/vocal_onset_heatmap.json" # ボーカル発音のヒートマップ
+  heatmap_resolution: 16 # ヒートマップ解像度（省略可）
+  heatmap_threshold: 2  # 強度判定の閾値（省略可）
 
 # ------------------- 2. Paths -----------------------
 paths:


### PR DESCRIPTION
## Summary
- add onset heatmap path and defaults in main config

## Testing
- `pip install music21 PyYAML pretty_midi pydub pytest`
- `pytest -q` *(fails: FileNotFoundError in test_timesig.py)*

------
https://chatgpt.com/codex/tasks/task_e_6849d169e4248328865489c301364f12