### PR TITLE
Implement heatmap-based ghost hat skipping

### DIFF
--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -254,6 +254,8 @@ class DrumGenerator(BasePartGenerator):
         self.vocal_midi_path = self.main_cfg.get("vocal_midi_path_for_drums")
         heatmap_json_path = self.main_cfg.get("heatmap_json_path_for_drums")
         self.heatmap = load_heatmap_data(heatmap_json_path)
+        self.heatmap_resolution = self.main_cfg.get("heatmap_resolution", RESOLUTION)
+        self.heatmap_threshold = self.main_cfg.get("heatmap_threshold", 1)
         self.rng = random.Random()
         if self.main_cfg.get("rng_seed") is not None:
             self.rng.seed(self.main_cfg["rng_seed"])
@@ -377,12 +379,12 @@ class DrumGenerator(BasePartGenerator):
                 logger.info(
                     f"DrumGen __init__: Added silent placeholder for undefined style '{style_key}' (from LUT)."
                 )
-        self.global_tempo = main_cfg.get("tempo", 120)
-        self.global_time_signature_str = main_cfg.get("time_signature", "4/4")
+        self.global_tempo = self.main_cfg.get("tempo", 120)
+        self.global_time_signature_str = self.main_cfg.get("time_signature", "4/4")
         self.global_ts = get_time_signature_object(self.global_time_signature_str)
         if not self.global_ts:
             logger.warning(
-                f"DrumGen __init__: Failed to parse global time_sig '{time_sig}'. Defaulting to 4/4."
+                f"DrumGen __init__: Failed to parse global time_sig '{self.global_time_signature_str}'. Defaulting to 4/4."
             )
             self.global_ts = meter.TimeSignature("4/4")
         self.instrument = m21instrument.Percussion()
@@ -860,6 +862,15 @@ class DrumGenerator(BasePartGenerator):
             final_insert_offset_in_score = (
                 bar_start_abs_offset + rel_offset_in_pattern + time_delta_from_humanizer
             )
+            bin_idx = int(
+                (final_insert_offset_in_score * self.heatmap_resolution)
+            ) % self.heatmap_resolution
+            bin_count = self.heatmap.get(bin_idx, 0)
+            if inst_name in {"ghost", "ghost_hat"} and bin_count >= self.heatmap_threshold:
+                logger.debug(
+                    f"{log_event_prefix}: Skip ghost hat at {final_insert_offset_in_score:.3f} (bin {bin_idx} count {bin_count})"
+                )
+                continue
             drum_hit_note.offset = 0.0
             part.insert(final_insert_offset_in_score, drum_hit_note)
 


### PR DESCRIPTION
## Summary
- allow DrumGenerator to load `heatmap_resolution` and `heatmap_threshold`
- fix references to `main_cfg` when reading tempo and time signature
- skip ghost-hat events when heatmap bin count meets threshold
- log skipped events for debugging

## Testing
- `python tools/test_timesig.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d17a8ed48328b6f9011b36d2af7b