### PR TITLE
Implement dynamic drum patterns with accent mapping

### DIFF
--- a/config/main_cfg.yml
+++ b/config/main_cfg.yml
@@ -25,6 +25,8 @@ global_settings:
   onset_heatmap_json: "data/vocal_onset_heatmap.json" # ボーカル発音のヒートマップ
   heatmap_resolution: 16 # ヒートマップ解像度（省略可）
   heatmap_threshold: 2  # 強度判定の閾値（省略可）
+  accent_threshold: 0.6
+  ghost_density_range: [0.3, 0.8]
 
 # ------------------- 2. Paths -----------------------
 paths:

--- a/data/drum_patterns.yml
+++ b/data/drum_patterns.yml
@@ -16,6 +16,34 @@ calm_backbeat:
     - instrument: hh
       offset: 3.0
 
+brush_light_loop:
+  description: "Soft brush groove"
+  pattern_type: "simple"
+  pattern:
+    - {instrument: kick, offset: 0.0}
+    - {instrument: snare, offset: 2.0}
+    - {instrument: chh, offset: 0.0}
+    - {instrument: chh, offset: 1.0}
+    - {instrument: chh, offset: 2.0}
+    - {instrument: chh, offset: 3.0}
+
+brush_build_loop:
+  description: "Brush build with extra hits"
+  pattern_type: "simple"
+  pattern:
+    - {instrument: kick, offset: 0.0}
+    - {instrument: snare, offset: 2.0}
+    - {instrument: kick, offset: 2.75}
+    - {instrument: snare, offset: 3.0}
+    - {instrument: chh, offset: 0.0}
+    - {instrument: chh, offset: 0.5}
+    - {instrument: chh, offset: 1.0}
+    - {instrument: chh, offset: 1.5}
+    - {instrument: chh, offset: 2.0}
+    - {instrument: chh, offset: 2.5}
+    - {instrument: chh, offset: 3.0}
+    - {instrument: chh, offset: 3.5}
+
 groove_pocket:
   description: "8分裏キックでグルーヴ感を演出"
   pattern_type: "simple"
@@ -91,6 +119,38 @@ neo_soul_pocket:
       offset: 1.75
     - instrument: ghost
       offset: 2.75
+
+rock_backbeat:
+  description: "Straight rock backbeat"
+  pattern_type: "simple"
+  pattern:
+    - {instrument: kick, offset: 0.0}
+    - {instrument: snare, offset: 2.0}
+    - {instrument: chh, offset: 0.0}
+    - {instrument: chh, offset: 0.5}
+    - {instrument: chh, offset: 1.0}
+    - {instrument: chh, offset: 1.5}
+    - {instrument: chh, offset: 2.0}
+    - {instrument: chh, offset: 2.5}
+    - {instrument: chh, offset: 3.0}
+    - {instrument: chh, offset: 3.5}
+
+rock_drive_loop:
+  description: "Driving rock beat"
+  pattern_type: "simple"
+  pattern:
+    - {instrument: kick, offset: 0.0}
+    - {instrument: kick, offset: 1.5}
+    - {instrument: snare, offset: 1.0}
+    - {instrument: snare, offset: 3.0}
+    - {instrument: chh, offset: 0.0}
+    - {instrument: chh, offset: 0.5}
+    - {instrument: chh, offset: 1.0}
+    - {instrument: chh, offset: 1.5}
+    - {instrument: chh, offset: 2.0}
+    - {instrument: chh, offset: 2.5}
+    - {instrument: chh, offset: 3.0}
+    - {instrument: chh, offset: 3.5}
 
 rock_anthem:
   description: "サビや盛り上がりで使える王道ロック"

--- a/data/rhythm_library.yml
+++ b/data/rhythm_library.yml
@@ -1013,3 +1013,21 @@ guitar_patterns:
     pattern_type: pedal_octave
     duration_beats: 8
     tags: [lh, pedal, calm]
+
+  fill_16th_toms:
+    description: "Rapid 16th tom fill"
+    pattern_type: drum_fill
+    pattern:
+      - {offset: 3.0, instrument: tom1}
+      - {offset: 3.25, instrument: tom2}
+      - {offset: 3.5, instrument: tom3}
+      - {offset: 3.75, instrument: tom2}
+      - {offset: 4.0, instrument: crash}
+
+  fill_8th_crash:
+    description: "Crash hits on 8ths"
+    pattern_type: drum_fill
+    pattern:
+      - {offset: 3.0, instrument: crash}
+      - {offset: 3.5, instrument: crash}
+      - {offset: 4.0, instrument: crash}


### PR DESCRIPTION
## Summary
- map emotion and intensity to drum style via LUT
- add AccentMapper and FillInserter utilities
- update drum generator to use new mapping and fills
- extend rhythm library and drum patterns
- expose accent and ghost hat controls in config
- refine heatmap utilities to return collapsed counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d844f88c8328be51a844dadad1dd