### PR TITLE
Fix duplicate mirror_melody parameter

### DIFF
--- a/generator/bass_generator.py
+++ b/generator/bass_generator.py
@@ -156,7 +156,6 @@ class BassGenerator(BasePartGenerator):
         global_key_signature_mode=None,
         mirror_melody: bool = False,
         main_cfg=None,
-        mirror_melody: bool = False,
         **kwargs,
     ):
         super().__init__(


### PR DESCRIPTION
## Summary
- fix syntax error in `BassGenerator.__init__` from duplicate argument

## Testing
- `bash setup.sh`
- `pytest -q` *(fails: TypeError in drum_generator `test_groove_offsets`)*

------
https://chatgpt.com/codex/tasks/task_e_6849f7b5eb5c8328a6d1247be2b820cb