### PR TITLE
Add CLI overrides for chordmap and rhythm files

### DIFF
--- a/config/main_cfg.yml
+++ b/config/main_cfg.yml
@@ -11,6 +11,8 @@ global_settings:
   song_title: "OreNoNyoubou_Shudaika"
   time_signature: "4/4" # ← デフォルト拍子
   tempo_bpm: 88 # ← デフォルトテンポ
+  # ↓ パッチ前からお使いの方でも互換性を保つようにしておく
+  # （CLI で上書きしなければこの default が使われます）
   key_tonic: "F"
   key_mode: "major"
 


### PR DESCRIPTION
## Summary
- support extra CLI options in `modular_composer.py`
- allow overriding chordmap, rhythm library and output directory
- add compatibility notes in `config/main_cfg.yml`

## Testing
- `bash setup.sh`
- `pytest -q` *(fails: TypeError in test_groove_offsets)*

------
https://chatgpt.com/codex/tasks/task_e_684a6dcca5708328b6ec83848e7941af