### PR TITLE
Fix drum fills duration and humanize profile bug

### DIFF
--- a/data/rhythm_library.yml
+++ b/data/rhythm_library.yml
@@ -1036,16 +1036,16 @@ drum_patterns:
     description: "Rapid 16th tom fill"
     pattern_type: drum_fill
     pattern:
-      - {offset: 3.0, instrument: tom1}
-      - {offset: 3.25, instrument: tom2}
-      - {offset: 3.5, instrument: tom3}
-      - {offset: 3.75, instrument: tom2}
-      - {offset: 4.0, instrument: crash}
+      - {offset: 3.00, duration: 0.25, instrument: tom1}
+      - {offset: 3.25, duration: 0.25, instrument: tom2}
+      - {offset: 3.50, duration: 0.25, instrument: tom3}
+      - {offset: 3.75, duration: 0.25, instrument: tom2}
+      - {offset: 4.00, duration: 0.25, instrument: crash}
 
   fill_8th_crash:
     description: "Crash hits on 8ths"
     pattern_type: drum_fill
     pattern:
-      - {offset: 3.0, instrument: crash}
-      - {offset: 3.5, instrument: crash}
-      - {offset: 4.0, instrument: crash}
+      - {offset: 3.00, duration: 0.5, instrument: crash}
+      - {offset: 3.50, duration: 0.5, instrument: crash}
+      - {offset: 4.00, duration: 0.5, instrument: crash}

--- a/generator/drum_generator.py
+++ b/generator/drum_generator.py
@@ -1254,9 +1254,7 @@ class DrumGenerator(BasePartGenerator):
                 logger.warning(f"Unknown drum instrument: '{inst_name}'")
 
         profile_name = (
-            self.main_cfg.get("humanize_profile")
             (self.main_cfg or {}).get("humanize_profile")
-
             or section_data.get("humanize_profile")
             or self.global_settings.get("humanize_profile")
         )


### PR DESCRIPTION
## Summary
- fix drum fill entries in `rhythm_library.yml` to include duration
- repair `humanize_profile` lookup logic in `drum_generator`

## Testing
- `pip install music21 pretty_midi pyyaml`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a74846c988328aac191fd8ec043a8